### PR TITLE
fix: data injection failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = function(options) {
                 const compiled = hb.compile(source);
                 file.contents = Buffer.from(compiled({
                     ...metalsmith._metadata,
-                    ...file
+                    ...file.data
                 }));
             } catch (e) {
                 console.log(


### PR DESCRIPTION
Due to the spread operator being applied on the file object instead of the data property of said file object the data is not injected correctly
![image](https://user-images.githubusercontent.com/24458276/126977765-c0e523b8-5df5-4ff6-9c52-2f9c943ef34b.png)

This is a PR to fix this bug